### PR TITLE
Add support for `RUST_REED_SOLOMON_ERASURE_ARCH` environment variable and stop using `native` architecture for SIMD code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.0.2
-* Add support for `RSE_ARCH` environment variable and stop using `native` architecture for SIMD code
+* Add support for `RUST_REED_SOLOMON_ERASURE_ARCH` environment variable and stop using `native` architecture for SIMD code
   - See [PR #98](https://github.com/rust-rse/reed-solomon-erasure/pull/98)
 
 ## 5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.2
+* Add support for `RSE_ARCH` environment variable and stop using `native` architecture for SIMD code
+  - See [PR #98](https://github.com/rust-rse/reed-solomon-erasure/pull/98)
+
 ## 5.0.1
 - The `simd-accel` feature now builds on M1 Macs
   - See [PR #92](https://github.com/rust-rse/reed-solomon-erasure/pull/92)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name= "reed-solomon-erasure"
-version = "5.0.1"
+version = "5.0.2"
 authors = ["Darren Ldl <darrenldldev@gmail.com>"]
 edition = "2018"
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ and the following to your crate root
 extern crate reed_solomon_erasure;
 ```
 
+NOTE: `simd-accel` is tuned for Haswell+ processors on x86-64 and not in any way for other architectures, set
+environment variable `RSE_ARCH` during build to force compilation of C code for specific architecture (`-march` flag in
+GCC/Clang). Even on x86-64 you can achieve better performance by setting it to `native`, but it will stop running on
+older CPUs, YMMV.
+
 ## Example
 ```rust
 #[macro_use(shards)]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ extern crate reed_solomon_erasure;
 ```
 
 NOTE: `simd-accel` is tuned for Haswell+ processors on x86-64 and not in any way for other architectures, set
-environment variable `RSE_ARCH` during build to force compilation of C code for specific architecture (`-march` flag in
+environment variable `RUST_REED_SOLOMON_ERASURE_ARCH` during build to force compilation of C code for specific architecture (`-march` flag in
 GCC/Clang). Even on x86-64 you can achieve better performance by setting it to `native`, but it will stop running on
 older CPUs, YMMV.
 

--- a/build.rs
+++ b/build.rs
@@ -161,7 +161,7 @@ fn compile_simd_c() {
     let mut build = cc::Build::new();
     build.opt_level(3);
 
-    match env::var("RSE_ARCH") {
+    match env::var("RUST_REED_SOLOMON_ERASURE_ARCH") {
         Ok(arch) => {
             // Use explicitly specified environment variable as architecture.
             build.flag(&format!("-march={}", arch));

--- a/build.rs
+++ b/build.rs
@@ -161,28 +161,19 @@ fn compile_simd_c() {
     let mut build = cc::Build::new();
     build.opt_level(3);
 
-    // `-march=native` is not supported on Apple M1
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    {
-        fn guess_target_cpu() -> String {
-            // Copied and adapted from https://github.com/alexcrichton/proc-macro2/blob/4173a21dc497c67326095e438ff989cc63cd9279/build.rs#L115
-            // Licensed under Apache-2.0 + MIT (compatible because we're MIT)
-            let rustflags = env::var_os("RUSTFLAGS").or(env::var_os("CARGO_ENCODED_RUSTFLAGS"));
-            if let Some(rustflags) = rustflags {
-                for mut flag in rustflags.to_string_lossy().split(&[' ', '\u{1f}'][..]) {
-                    if flag.starts_with("-C") {
-                        flag = &flag["-C".len()..];
-                    }
-                    if flag.starts_with("target-cpu=") {
-                        return flag["target-cpu=".len()..].to_owned();
-                    }
-                }
-            }
-
-            "native".to_string()
+    match env::var("RSE_ARCH") {
+        Ok(arch) => {
+            // Use explicitly specified environment variable as architecture.
+            build.flag(&format!("-march={}", arch));
         }
-        build.flag(&format!("-march={}", guess_target_cpu()));
+        Err(_error) => {
+            // On x86-64 enabling Haswell architecture unlocks useful instructions and improves performance
+            // dramatically while allowing it to run ony modern CPU.
+            #[cfg(target_arch = "x86_64")]
+            build.flag(&"-march=haswell");
+        }
     }
+
     build
         .flag("-std=c11")
         .file("simd_c/reedsolomon.c")


### PR DESCRIPTION
On Zen3 5900X CPU performance decreases with this change from 21035 MB/s to 19650 MB/s.

This is significant, but unlikely deal-breaking and on the flip side we support way more CPUs (Haswell+). If this is a problem, it is still possible to tune it for a specific architecture or just `native` where it is supported.

The reason for dropping `RUSTFLAGS` and `CARGO_ENCODED_RUSTFLAGS` is mismatch between target CPUs there and in GCC as described in #97.

This fixes #94 and closes #95, closes #97.

This approach is much safer than discovering more and more platforms where `native` causes issues.

cc @SvenDowideit, @i1i1