### PR TITLE
Fix cross build bug for aarch64 with simd-accel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.3
+- Fixed cross build bug for aarch64 with simd-accel
+  - See [PR #100](https://github.com/rust-rse/reed-solomon-erasure/pull/100)
+
 ## 5.0.2
 * Add support for `RUST_REED_SOLOMON_ERASURE_ARCH` environment variable and stop using `native` architecture for SIMD code
   - See [PR #98](https://github.com/rust-rse/reed-solomon-erasure/pull/98)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name= "reed-solomon-erasure"
-version = "5.0.2"
+version = "5.0.3"
 authors = ["Darren Ldl <darrenldldev@gmail.com>"]
 edition = "2018"
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -169,8 +169,10 @@ fn compile_simd_c() {
         Err(_error) => {
             // On x86-64 enabling Haswell architecture unlocks useful instructions and improves performance
             // dramatically while allowing it to run ony modern CPU.
-            #[cfg(target_arch = "x86_64")]
-            build.flag(&"-march=haswell");
+            match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str(){
+                "x86_64"  => { build.flag(&"-march=haswell"); },
+                _         => ()
+            }
         }
     }
 


### PR DESCRIPTION
This patch has done 3 things: 
1. **Fix cross build bug for aarch64 with simd-accel**
The current logic in build.rs `#[cfg(target_arch = "x86_64")]` will fail when cross build for aarch64.
As the build.rs will be compiled to a binary on host, the `target_arch` value will be set to host architecture.
Instead, we should read `target_arch` from environment. Reproduce it on a x86_64 linux host:
`cargo build --target=aarch64-unknown-linux-gnu --features=simd-accel -vv`

2. **Set -march=armv8-a as default value for aarch64**
I think we should set a default -march value for aarch64, and this has been tested for aarch64-linux and aarch64-darwin (Apple M1).  

3. **Enable aarch64 + simd-accel for Android build**
Enable simd-accel feature for android, and maybe we can also do it for iOS? 

I don't know much about MacOS and iOS, please correct me if there is any mistake~
releated: #98 #95 #92