### PR TITLE
restore fuzz harness

### DIFF
--- a/fuzz/fuzz_targets/fuzz_encode_verify.rs
+++ b/fuzz/fuzz_targets/fuzz_encode_verify.rs
@@ -2,7 +2,7 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate reed_solomon_erasure;
 
-use reed_solomon_erasure::ReedSolomon;
+use reed_solomon_erasure::{galois_8, ReedSolomon};
 
 fuzz_target!(|data: &[u8]| {
     if data.len() >= 4 {
@@ -19,7 +19,8 @@ fuzz_target!(|data: &[u8]| {
             && data_shards + parity_shards <= 256
             && data.len() == data_shards * shard_size
         {
-            let codec = ReedSolomon::new(data_shards, parity_shards).unwrap();
+            let codec: ReedSolomon<galois_8::Field> =
+                ReedSolomon::new(data_shards, parity_shards).unwrap();
 
             for _ in 0..run_count {
                 assert_eq!(codec.data_shard_count(), data_shards);


### PR DESCRIPTION
I made some updates to the fuzz harnesses so they can now compile and run, please let me know if it looks ok!

I did find a test case that fails this assertion, however. And that makes me think I might have not done it correctly. https://github.com/rust-rse/reed-solomon-erasure/blob/eb1f66f4784bf2ea35dccfca570306b6fb9679c1/fuzz/fuzz_targets/fuzz_encode_reconstruct.rs#L84

Here's the testcase (just gunzip it first): [crash-f61a3a5145f24900354a66763966d333a421ebdc.gz](https://github.com/rust-rse/reed-solomon-erasure/files/8985644/crash-f61a3a5145f24900354a66763966d333a421ebdc.gz)